### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/Corvus/Corvus_CF.version
+++ b/GameData/Corvus/Corvus_CF.version
@@ -21,7 +21,7 @@
         "PATCH": 0
     },
     "NAME": "Corvus CF",
-    "URL": "https://raw.githubusercontent.com/mwerle/Corvus_CF/master/Corvus_CF.version",
+    "URL": "https://github.com/mwerle/Corvus_CF/raw/master/GameData/Corvus/Corvus_CF.version",
     "VERSION": {
         "MAJOR": 1,
         "MINOR": 3,


### PR DESCRIPTION
The current version file's URL property is a 404.
Now it's fixed.